### PR TITLE
feat: Added option to visualization to link two axes in either x, y or xy direction

### DIFF
--- a/tests/tests/test_visualization.py
+++ b/tests/tests/test_visualization.py
@@ -40,3 +40,13 @@ import LDAQ
 #     assert vis.subplot_options[(0, 0)]['axis_style'] == 'semilogy'
 #     assert vis.subplot_options[(0, 0)]['colspan'] == 1
 #     assert vis.subplot_options[(0, 0)]['rowspan'] == 1
+
+#     vis.config_subplot((0, 1), xlim=(0, 10), title='Test title 2nd subplot', linked_axis=(0, 0), link_kind='y')
+
+#     assert (0, 1) in vis.subplot_options.keys()
+#     assert vis.subplot_options[(0, 1)]['xlim'] == (0, 10)
+#     assert vis.subplot_options[(0, 1)]['title'] == 'Test title 2nd subplot'
+#     assert vis.subplot_options[(0, 1)]['linked_axis'] == (0, 0)
+#     assert vis.subplot_options[(0, 1)]['link_kind'] == 'y'
+#     assert vis.subplot_options[(0, 1)]['colspan'] == 1
+#     assert vis.subplot_options[(0, 1)]['rowspan'] == 1


### PR DESCRIPTION
Also adds a very rudimentary test case to the (commented?) tests.

So far there is no checking if the axis that is being linked to actually exists. If it doesn't an exception is raised when trying to access the subplot data for the non-existent axis/plot.